### PR TITLE
Add scala 2.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.class
 *.log
+.idea
+*.iml
 
 # sbt specific
 .cache

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,19 @@
 organization := "com.github.mitallast"
 name := "scala-nsq"
-version := "1.11"
+version := "1.11.2"
 
 description := "Scala NSQ client"
 
-scalaVersion := "2.11.8"
+crossScalaVersions := Seq("2.11.8", "2.12.4")
+scalaVersion := "2.12.4"
 
 libraryDependencies += "io.netty" % "netty-all" % "4.0.40.Final"
 libraryDependencies += "com.typesafe" % "config" % "1.3.0"
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.21"
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.21" % "test"
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.2" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.github.mitallast"
 name := "scala-nsq"
-version := "1.11.2"
+version := "1.12"
 
 description := "Scala NSQ client"
 


### PR DESCRIPTION
Hi, here's a PR to add cross-compile support for 2.12.4, and the current version of 2.11 that the lib uses. I tried to keep the changes minimal - scalatest and scalacheck needed to be upgraded to add their cross-compile support.

